### PR TITLE
Add ccache ImageMagick build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: ruby
 
+cache:
+  directories:
+    - ~/.ccache
+
 os:
   - linux
 


### PR DESCRIPTION
This PR lowers the CI build time by caching the ImageMagick build process on Travis.

Builds were taking about ~7min to complete, with this PR, once cached, the build now finishes after around ~3min.

Related to #27 (resolves the problem specified in it)