### PR TITLE
Fix Travis CI badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_install:
 
 addons:
   code_climate:
-    repo_token: 6da7995a8ca918ac0902d60dc0eb49aa6ae2b94730ea0024e15dcc8f73dd3b1c
+    repo_token: 1abcca9cc0cab51bf0ba6c87cf5e0c68ca7830bc4dcba9728579950ab0a0ee1d

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Ruby Marks
 ==========
 
-[![Build Status](https://secure.travis-ci.org/andrerpbts/ruby_marks.png?branch=master)](http://travis-ci.org/andrerpbts/ruby_marks)
-[![Code Climate](https://codeclimate.com/github/andrerpbts/ruby_marks/badges/gpa.svg)](https://codeclimate.com/github/andrerpbts/ruby_marks)
-[![Test Coverage](https://codeclimate.com/github/andrerpbts/ruby_marks/badges/coverage.svg)](https://codeclimate.com/github/andrerpbts/ruby_marks)
+[![Build Status](https://travis-ci.org/ruby-marks/ruby-marks.svg?branch=master)](https://travis-ci.org/ruby-marks/ruby-marks)
+[![Maintainability](https://api.codeclimate.com/v1/badges/c6cbd936857fd70812dc/maintainability)](https://codeclimate.com/github/ruby-marks/ruby-marks/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/c6cbd936857fd70812dc/test_coverage)](https://codeclimate.com/github/ruby-marks/ruby-marks/test_coverage)
 
 A simple OMR ([Optical Mark Recognition](http://en.wikipedia.org/wiki/Optical_mark_recognition)) gem for ruby.
 


### PR DESCRIPTION
Hi! I saw that the repo was displaying `build: unknown` status on travis badge, so I've created this PR which points to the correct travis ci badge.

(The codeclimate and the test coverage badge are also pointing to the old owner but they don't seem to be displaying incorrect data)