### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/ruby_marks.gemspec
+++ b/ruby_marks.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.test_files              = Dir['test/**/*']
   s.require_paths           = ['lib']
   s.licenses                = ['MIT']
-  s.rubyforge_project       = 'ruby_marks'
   # s.extra_rdoc_files        = ['README.md']
 
   # Dependencies


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.